### PR TITLE
Future proofing by implementing "type":"module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "orbital",
   "version": "0.1.0",
+  "type": "module",
   "private": true,
   "dependencies": {
     "@hookform/resolvers": "^3.0.0",


### PR DESCRIPTION
Hi,

I’ve added `"type": "module"` to the package.json file. This change switches your project to use ECMAScript Modules (ESM), which is the modern way of handling modules in JavaScript.

Check out examples below⬇️

1) `"type": "module"` ❌

```
// Importing
const fs = require('fs');
const myModule = require('./myModule');
fs.readFileSync('/path/to/file');
myModule.doSomething();

// Exporting
module.exports = {
  doSomething,
};
```

2) `"type": "module"` ✅

```
// Importing
import fs from 'fs';
import { doSomething } from './myModule.js';
fs.readFileSync('/path/to/file');
doSomething();

// Exporting
export const doSomething = () => {
  console.log('Doing something');
};
```